### PR TITLE
Update User Guide's Supported Machine List To Match Release Notes'

### DIFF
--- a/user-guide/source/machine-list.inc
+++ b/user-guide/source/machine-list.inc
@@ -1,39 +1,65 @@
-=========================  ==================================================  ==========  ==========
-         Machine             Name                                                 SoC        Layer
-=========================  ==================================================  ==========  ==========
-imx6qsabrelite             Boundary Devices i.MX6Q SABRE Lite                  i.MX6Q      meta-fsl-arm-extra
-nitrogen6x                 Boundary Devices Nitrogen6X                         i.MX6Q      meta-fsl-arm-extra
-nitrogen6x-lite            Boundary Devices Nitrogen6X Lite                    i.MX6 Solo  meta-fsl-arm-extra
-cgtqmx6                    Congatec Qmx6                                       i.MX6Q      meta-fsl-arm-extra
-cfa10036                   Crystalfontz CFA-10036                              i.MX28      meta-fsl-arm-extra
-cfa10037                   Crystalfontz CFA-10037                              i.MX28      meta-fsl-arm-extra
-cfa10049                   Crystalfontz CFA-10049                              i.MX28      meta-fsl-arm-extra
-cfa10055                   Crystalfontz CFA-10055                              i.MX28      meta-fsl-arm-extra
-cfa10056                   Crystalfontz CFA-10056                              i.MX28      meta-fsl-arm-extra
-cfa10057                   Crystalfontz CFA-10057                              i.MX28      meta-fsl-arm-extra
-cfa10058                   Crystalfontz CFA-10058                              i.MX28      meta-fsl-arm-extra
-m28evk                     DENX M28 SoM Evaluation Kit                         i.MX28      meta-fsl-arm-extra
-m53evk                     DENX M53 SoM Evaluation Kit                         i.MX53      meta-fsl-arm-extra
-imx23evk                   Freescale i.MX23 Evaluation Kit                     i.MX23      meta-fsl-arm
-imx28evk                   Freescale i.MX28 Evaluation Kit                     i.MX28      meta-fsl-arm
-imx31pdk                   Freescale i.MX31 Platform Development Kit           i.MX31      meta-fsl-arm
-imx35pdk                   Freescale i.MX35 Platform Development Kit           i.MX35      meta-fsl-arm
-imx51evk                   Freescale i.MX51 Evaluation Kit                     i.MX51      meta-fsl-arm
-imx53qsb                   Freescale i.MX53 Quick Start Board                  i.MX53      meta-fsl-arm
-imx53ard                   Freescale i.MX53 SABRE Automotive Board             i.MX53      meta-fsl-arm
-imx6dlsabreauto            Freescale i.MX6DL SABRE Automotive                  i.MX6DL     meta-fsl-arm
-imx6dlsabresd              Freescale i.MX6DL SABRE Smart Device                i.MX6DL     meta-fsl-arm
-imx6qsabreauto             Freescale i.MX6Q SABRE Automotive                   i.MX6Q      meta-fsl-arm
-imx6qsabresd               Freescale i.MX6Q SABRE Smart Device                 i.MX6Q      meta-fsl-arm
-imx6slevk                  Freescale i.MX6SL Evaluation Kit                    i.MX6SL     meta-fsl-arm
-imx6solosabreauto          Freescale i.MX6Solo SABRE Automotive                i.MX6S      meta-fsl-arm
-imx6solosabresd            Freescale i.MX6Solo SABRE Smart Device              i.MX6S      meta-fsl-arm
-twr-vf65gs10               Freescale Vybrid TWR-VF65GS10                       vf60        meta-fsl-arm
-imx233-olinuxino-maxi      OLIMEX iMX233-OLinuXino-Maxi                        i.MX23      meta-fsl-arm-extra
-imx233-olinuxino-micro     OLIMEX iMX233-OLinuXino-Micro                       i.MX23      meta-fsl-arm-extra
-imx233-olinuxino-mini      OLIMEX iMX233-OLinuXino-Mini                        i.MX23      meta-fsl-arm-extra
-imx233-olinuxino-nano      OLIMEX iMX233-OLinuXino-Nano                        i.MX23      meta-fsl-arm-extra
-wandboard-dual             Wandboard i.MX6 Wandboard Duallite                  i.MX6DL     meta-fsl-arm-extra
-wandboard-quad             Wandboard i.MX6 Wandboard Quad                      i.MX6Q      meta-fsl-arm-extra
-wandboard-solo             Wandboard i.MX6 Wandboard Solo                      i.MX6S      meta-fsl-arm-extra
-=========================  ==================================================  ==========  ==========
+======================  ==================================================  =======================  ==================
+       Machine                                 Name                                   SoC                  Layer
+======================  ==================================================  =======================  ==================
+apalis-imx6             Toradex Apalis iMX6Q/D                              i.MX6                    meta-fsl-arm-extra
+cfa10036                Crystalfontz CFA-10036                              i.MX28                   meta-fsl-arm-extra
+cfa10037                Crystalfontz CFA-10037                              i.MX28                   meta-fsl-arm-extra
+cfa10049                Crystalfontz CFA-10049                              i.MX28                   meta-fsl-arm-extra
+cfa10055                Crystalfontz CFA-10055                              i.MX28                   meta-fsl-arm-extra
+cfa10056                Crystalfontz CFA-10056                              i.MX28                   meta-fsl-arm-extra
+cfa10057                Crystalfontz CFA-10057                              i.MX28                   meta-fsl-arm-extra
+cfa10058                Crystalfontz CFA-10058                              i.MX28                   meta-fsl-arm-extra
+cgtqmx6                 Congatec QMX6 Evaluation board                      i.MX6 Q/DL               meta-fsl-arm-extra
+cm-fx6                  CompuLab CM-FX6                                     i.MX6 Q/DL               meta-fsl-arm-extra
+colibri-imx6            Toradex Colibri iMX6DL/S                            i.MX6 DL/S               meta-fsl-arm-extra
+colibri-imx7            Toradex Colibri iMX7D/S                             i.MX 7Dual / i.MX 7Solo  meta-fsl-arm-extra
+colibri-vf              Toradex Colibri VF50/VF61                           VF500/VF610              meta-fsl-arm-extra
+cubox-i                 SolidRun CuBox-i and HummingBoard                   i.MX6 Q/DL               meta-fsl-arm-extra
+imx233-olinuxino-maxi   OLIMEX iMX233-OLinuXino-Maxi                        i.MX23                   meta-fsl-arm-extra
+imx233-olinuxino-micro  OLIMEX iMX233-OLinuXino-Micro                       i.MX23                   meta-fsl-arm-extra
+imx233-olinuxino-mini   OLIMEX iMX233-OLinuXino-Mini                        i.MX23                   meta-fsl-arm-extra
+imx233-olinuxino-nano   OLIMEX iMX233-OLinuXino-Nano                        i.MX23                   meta-fsl-arm-extra
+imx23evk                Freescale i.MX23 Evaluation Kit                     i.MX23                   meta-fsl-arm
+imx28evk                Freescale i.MX28 Evaluation Kit                     i.MX28                   meta-fsl-arm
+imx51evk                Freescale i.MX51 Evaluation Kit                     i.MX51                   meta-fsl-arm
+imx53ard                Freescale i.MX53 SABRE Automotive Board             i.MX53                   meta-fsl-arm
+imx53qsb                Freescale i.MX53 Quick Start Board                  i.MX53                   meta-fsl-arm
+imx6dl-riotboard        RIoTboard                                           i.MX6S                   meta-fsl-arm-extra
+imx6dlsabreauto         Freescale i.MX6DL SABRE Automotive                  i.MX6DL                  meta-fsl-arm
+imx6dlsabresd           Freescale i.MX6DL SABRE Smart Device                i.MX6DL                  meta-fsl-arm
+imx6q-dms-ba16          Advantech DMS BA16                                  i.MX6Q                   meta-fsl-arm-extra
+imx6qdl-variscite-som   Variscite i.MX6Q/DL VAR-SOM-MX6                     i.MX6Q/DL                meta-fsl-arm-extra
+imx6qpsabreauto         Freescale i.MX6Q Plus SABRE Automotive              i.MX6QP                  meta-fsl-arm
+imx6qpsabresd           Freescale i.MX6Q Plus SABRE Smart Device            i.MX6QP                  meta-fsl-arm
+imx6qsabreauto          Freescale i.MX6Q SABRE Automotive                   i.MX6Q                   meta-fsl-arm
+imx6qsabrelite          Boundary Devices i.MX6Q SABRE Lite                  i.MX6Q                   meta-fsl-arm-extra
+imx6qsabresd            Freescale i.MX6Q SABRE Smart Device                 i.MX6Q                   meta-fsl-arm
+imx6sl-warp             WaRP                                                i.MX6SL                  meta-fsl-arm-extra
+imx6slevk               Freescale i.MX6SL Evaluation Kit                    i.MX6SL                  meta-fsl-arm
+imx6solosabreauto       Freescale i.MX6Solo SABRE Automotive                i.MX6S                   meta-fsl-arm
+imx6solosabresd         Freescale i.MX6Solo SABRE Smart Device              i.MX6S                   meta-fsl-arm
+imx6sxsabreauto         Freescale i.MX6SoloX Sabre Automotive               i.MX6SX                  meta-fsl-arm
+imx6sxsabresd           Freescale i.MX6SoloX SabreSD                        i.MX6SX                  meta-fsl-arm
+imx6ul-pico-hobbit      Hobbitboard (PICO-IMX6UL)                           i.MX6UL                  meta-fsl-arm-extra
+imx6ulevk               Freescale i.MX6UL Evaluation Kit                    i.MX6UL                  meta-fsl-arm
+imx7dsabresd            Freescale i.MX7D SABRE Smart Device                 i.MX7D                   meta-fsl-arm
+imx7s-warp              WaRP7                                               i.MX7S                   meta-fsl-arm-extra
+ls1021atwr              Freescale LS1021ATWR board                          ls102xa                  meta-fsl-arm
+m28evk                  DENX M28 SoM Evaluation Kit                         i.MX28                   meta-fsl-arm-extra
+m53evk                  DENX M53 SoM Evaluation Kit                         i.MX53                   meta-fsl-arm-extra
+nitrogen6sx             Boundary Devices Nitrogen6SX                        i.MX6SX                  meta-fsl-arm-extra
+nitrogen6x              Boundary Devices Nitrogen6X                         i.MX6 Q/DL               meta-fsl-arm-extra
+nitrogen6x-lite         Boundary Devices Nitrogen6X Lite                    i.MX6S                   meta-fsl-arm-extra
+nitrogen7               Boundary Devices Nitrogen7                          i.MX7D                   meta-fsl-arm-extra
+pcm052                  Phytec phyCORE Vybrid Development Kit               vf60                     meta-fsl-arm-extra
+twr-vf65gs10            Freescale Vybrid TWR-VF65GS10                       VF610                    meta-fsl-arm
+tx6q-10x0               Ka-Ro electronics i.MX6Q TX6Q Computer-On-Module    i.MX6Q                   meta-fsl-arm-extra
+tx6q-11x0               Ka-Ro electronics i.MX6Q TX6Q Computer-On-Module    i.MX6Q                   meta-fsl-arm-extra
+tx6s-8034               Ka-Ro electronics i.MX6S TX6S Computer-On-Module    i.MX6S                   meta-fsl-arm-extra
+tx6s-8035               Ka-Ro electronics i.MX6S TX6S Computer-On-Module    i.MX6S                   meta-fsl-arm-extra
+tx6u-8033               Ka-Ro electronics i.MX6DL TX6DL Computer-On-Module  i.MX6DL                  meta-fsl-arm-extra
+tx6u-80x0               Ka-Ro electronics i.MX6DL TX6DL Computer-On-Module  i.MX6DL                  meta-fsl-arm-extra
+tx6u-81x0               Ka-Ro electronics i.MX6DL TX6DL Computer-On-Module  i.MX6DL                  meta-fsl-arm-extra
+ventana                 i.MX6Q/DL Ventana Platform                          i.MX6Q/DL                meta-fsl-arm-extra
+wandboard               Wandboard i.MX6 Wandboard Quad/Dual/Solo            i.MX6Q/DL                meta-fsl-arm-extra
+======================  ==================================================  =======================  ==================

--- a/user-guide/source/machines.rst
+++ b/user-guide/source/machines.rst
@@ -7,5 +7,8 @@ The scope of this release includes both meta-fsl-arm and meta-fsl-arm-extra.
 Please refer to the table below for the complete list of supported boards.
 
 
-.. include:: machine-list.inc
+.. tabularcolumns:: c | p{5cm} | c | c
+.. table:: Supported machines
+
+   .. include:: machine-list.inc
 


### PR DESCRIPTION
The Release Notes have been kept more up to date than the User Guide.
This has resulted in the correct data for machine-list.inc being present
in the release-notes source code but the user-guide version becoming out
of date.

This changeset updates the user-guide/source/machine-list.inc to match
to one currently found in release-notes/source/machine-list.inc.  It also 
updates the styling of the table displayed in the User Guide to match that 
of the Release Notes, primarily to avoid the longer field data running off
the end of a line.  

A future update should be made to automatically base the user-guide
version on the release-notes version so that there are not two identical
sets of information to be maintained.  For now the pragmatic thing to do
is bring the user-guide up to date.