### PR TITLE
Fix links to the meta-freescale mailing list

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ for useful guidelines to be followed when submitting patches.
 
 Mailing list:
 
-    https://lists.yoctoproject.org/listinfo/meta-freescale
+    https://lists.yoctoproject.org/g/meta-freescale/
 
 Source code:
 

--- a/release-notes/source/introduction.rst
+++ b/release-notes/source/introduction.rst
@@ -15,7 +15,7 @@ support for OpenEmbedded and Yocto Project.
       considered finished*.  In case you wish to contribute with
       suggestions, fixes or comments, then please get in touch
       through the `meta-freescale
-      <https://lists.yoctoproject.org/listinfo/meta-freescale>`_
+      <https://lists.yoctoproject.org/g/meta-freescale/>`_
       mailing list.
 
 .. only:: latex
@@ -50,7 +50,7 @@ The |project_name| provides:
 
  * common environment configuration;
  * multiple download layers with the use of `repo <https://github.com/Freescale/fsl-community-bsp-platform>`_;
- * common `location <https://lists.yoctoproject.org/listinfo/meta-freescale>`_
+ * common `location <https://lists.yoctoproject.org/g/meta-freescale/>`_
    for discussing Freescale SoCs, kernels, bootloaders, user space
    packages, (BSP in general), bugs, how-tos, and so on
 

--- a/user-guide/source/devtasks.rst
+++ b/user-guide/source/devtasks.rst
@@ -225,4 +225,4 @@ where ``<patch>`` is the file created by ``git format-patch``.
 
 .. links
 .. _Layer Index: http://layers.openembedded.org/layerindex/layers/
-.. _meta-freescale Mailing List: https://lists.yoctoproject.org/listinfo/meta-freescale
+.. _meta-freescale Mailing List: https://lists.yoctoproject.org/g/meta-freescale/

--- a/user-guide/source/nsteps.rst
+++ b/user-guide/source/nsteps.rst
@@ -81,4 +81,4 @@ Found errors? Subscribe and report it to `meta-freescale list`_
 .. links
 .. _required host packages: https://www.yoctoproject.org/docs/current/yocto-project-qs/yocto-project-qs.html#packages
 .. _repo: http://source.android.com/source/downloading.html
-.. _meta-freescale list: https://lists.yoctoproject.org/listinfo/meta-freescale
+.. _meta-freescale list: https://lists.yoctoproject.org/g/meta-freescale/


### PR DESCRIPTION
The meta-freescale mailing list was recently migrated to Groups.io.
Update the links in the documentation to point to the new location.