### PR TITLE
Deprecate Documentation

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,12 @@
 Freescale Community BSP Documentation
 -------------------------------------
 
+DEPRECATED
+----------
+
+This repository is archived. It is not up-to-date and so far there is no plan
+to update this.
+
 The documentation is written using the Sphinx documentation system. To
 install it in Debian/Ubuntu, please do:
 


### PR DESCRIPTION
The Documentation is currently out of date and there is no plan to fix the script to update the file. So, let's archive the repo.